### PR TITLE
Add `dataSet` prop to Expo Button example

### DIFF
--- a/examples/expo/src/Button.tsx
+++ b/examples/expo/src/Button.tsx
@@ -27,8 +27,10 @@ export const Button: FunctionComponent<ButtonProps> = ({ label, onPress }) => {
       onPressOut={() => setPressed(false)}
       onPress={onPress}
     >
-      <View style={styles.button}>
-        <Text style={styles.text}>{label}</Text>
+      <View style={styles.button} dataSet={{ tw: styles.button.id }}>
+        <Text style={styles.text} dataSet={{ tw: styles.text.id }}>
+          {label}
+        </Text>
       </View>
     </TouchableWithoutFeedback>
   )


### PR DESCRIPTION
The example was missing passing the responsive IDs via the `dataSet` prop. This is one of the main caveats of `useTailwindStyles`, we might be able to also _magically_ apply the prop through the macro, but that is a different, more complicated, story.

Closes #7 